### PR TITLE
fix test of sure shots

### DIFF
--- a/src/Checker/ReferenceAssignmentChecker.php
+++ b/src/Checker/ReferenceAssignmentChecker.php
@@ -4,6 +4,7 @@
 namespace umulmrum\PhpReferenceChecker\Checker;
 
 
+use PhpParser\Error;
 use PhpParser\Node\Expr\AssignRef;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Stmt\Class_;
@@ -92,6 +93,9 @@ class ReferenceAssignmentChecker
             $methods = $node->getMethods();
             foreach ($methods as $method) {
                 $stmts = $method->getStmts();
+                if (!is_iterable($stmts)) {
+                    continue;
+                }
                 foreach ($stmts as $stmt) {
                     if (false === $stmt instanceof AssignRef) {
                         continue;
@@ -115,7 +119,7 @@ class ReferenceAssignmentChecker
                         $warnings[] = new NonReferenceAssignmentWarning(basename($path), $expr->getLine(), 1.0);
                         continue;
                     }
-                    if ($referenceReturns > 0) {
+                    if ($referenceReturns > 0 && $nonReferenceReturns > 0) {
                         // this may be ok
                         $warnings[] = new NonReferenceAssignmentWarning(
                             basename($path),
@@ -171,7 +175,13 @@ class ReferenceAssignmentChecker
     private function addToRepository($filePath, MethodRepository $repository)
     {
         $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
-        $nodes = $parser->parse(file_get_contents($filePath));
+        try {
+            $nodes = $parser->parse(file_get_contents($filePath));
+        } catch (Error $e) {
+            $this->logger->warning($filePath . ': ' . $e->getMessage());
+            return;
+        }
+
         foreach ($nodes as $node) {
             if (false === $node instanceof Class_) {
                 continue; // TODO check functions defined outside of classes

--- a/src/Checker/ReferenceAssignmentChecker.php
+++ b/src/Checker/ReferenceAssignmentChecker.php
@@ -114,7 +114,7 @@ class ReferenceAssignmentChecker
                     $nonReferenceReturns = isset($repository->getNonReferenceReturnMethods()[$name]) ? $repository->getNonReferenceReturnMethods()[$name] : 0;
                     $referenceReturns = isset($repository->getReferenceReturnMethods()[$name]) ? $repository->getReferenceReturnMethods()[$name] : 0;
 
-                    if ($referenceReturns === 0) {
+                    if ($referenceReturns === 0 && $nonReferenceReturns > 0) {
                         // we know it is not ok!
                         $warnings[] = new NonReferenceAssignmentWarning(basename($path), $expr->getLine(), 1.0);
                         continue;

--- a/tests/Checker/ReferenceAssignmentCheckerTest.php
+++ b/tests/Checker/ReferenceAssignmentCheckerTest.php
@@ -6,6 +6,7 @@ namespace umulmrum\PhpReferenceChecker\Checker;
 
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use umulmrum\PhpReferenceChecker\DataModel\NonReferenceAssignmentWarning;
 
 class ReferenceAssignmentCheckerTest extends TestCase
@@ -93,9 +94,19 @@ class ReferenceAssignmentCheckerTest extends TestCase
         );
     }
 
+    public function testSure()
+    {
+        $this->givenAReferenceAssignmentChecker();
+        $this->whenICallCheckOn(
+            __DIR__.'/../fixtures/Certainty/Sure.php',
+            __DIR__.'/../fixtures/Certainty/Sure.php'
+        );
+        $this->thenIShouldReceiveNoWarning();
+    }
+
     private function givenAReferenceAssignmentChecker()
     {
-        $this->checker = new ReferenceAssignmentChecker(new Logger('test'));
+        $this->checker = new ReferenceAssignmentChecker(new NullLogger());
     }
 
     private function whenICallCheckOn($checkFilePath, $repoPath)
@@ -116,5 +127,10 @@ class ReferenceAssignmentCheckerTest extends TestCase
     {
         $expected = [$level, false];
         static::assertContains(ini_get('xdebug.max_nesting_level'), $expected);
+    }
+
+    private function thenIShouldReceiveNoWarning()
+    {
+        static::assertEmpty($this->actualResult);
     }
 }

--- a/tests/fixtures/Certainty/Sure.php
+++ b/tests/fixtures/Certainty/Sure.php
@@ -1,0 +1,25 @@
+<?php
+
+class SureOne {
+    public function &foo()
+    {
+        return 'foo';
+    }
+}
+
+class SureTwo {
+    public function &foo()
+    {
+        $foo = 'foo';
+        return $foo;
+    }
+}
+
+class SureCaller {
+    public function caller()
+    {
+        $cls = new SureOne();
+        $foo = '';
+        $foo =& $cls->foo();
+    }
+}


### PR DESCRIPTION
should there be mor than zero reference returns, only generate
a warning, if there are also non reference returns.

I also sneaked in a little more fault tolerance into this commit. I know, it should be its own PR, so feel free to reject this PR because of this (but don't).