### PR TITLE
Switch to NodeTraverser and NodeVisitor

### DIFF
--- a/src/Checker/AssignByReferenceVisitor.php
+++ b/src/Checker/AssignByReferenceVisitor.php
@@ -1,0 +1,81 @@
+<?php
+
+
+namespace umulmrum\PhpReferenceChecker\Checker;
+
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\AssignRef;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\NodeVisitorAbstract;
+use umulmrum\PhpReferenceChecker\DataModel\MethodRepository;
+use umulmrum\PhpReferenceChecker\DataModel\NonReferenceAssignmentWarning;
+
+class AssignByReferenceVisitor extends NodeVisitorAbstract
+{
+
+    /**
+     * @var array
+     */
+    private $warnings;
+    /**
+     * @var MethodRepository
+     */
+    private $repository;
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @param array            $warnings
+     * @param MethodRepository $repository
+     * @param string           $path
+     */
+    public function __construct(array &$warnings, MethodRepository $repository, $path)
+    {
+        $this->warnings =& $warnings;
+        $this->repository = $repository;
+        $this->path = $path;
+    }
+
+    public function enterNode(Node $node)
+    {
+        parent::enterNode($node);
+
+        if (false === $node instanceof AssignRef) {
+            return null;
+        }
+        /**
+         * @var AssignRef $node
+         */
+        $expr = $node->expr;
+        if (false === $expr instanceof MethodCall) {
+            return null;
+        }
+        /**
+         * @var MethodCall $expr
+         */
+        $name = $expr->name;
+        $nonReferenceReturns = isset($this->repository->getNonReferenceReturnMethods()[$name]) ? $this->repository->getNonReferenceReturnMethods()[$name] : 0;
+        $referenceReturns = isset($this->repository->getReferenceReturnMethods()[$name]) ? $this->repository->getReferenceReturnMethods()[$name] : 0;
+
+        if ($referenceReturns === 0 && $nonReferenceReturns > 0) {
+            // we know it is not ok!
+            $this->warnings[] = new NonReferenceAssignmentWarning(basename($this->path), $expr->getLine(), 1.0);
+            return null;
+        }
+        if ($referenceReturns > 0 && $nonReferenceReturns > 0) {
+            // this may be ok
+            $this->warnings[] = new NonReferenceAssignmentWarning(
+                basename($this->path),
+                $expr->getLine(),
+                $referenceReturns / ($nonReferenceReturns + $referenceReturns)
+            );
+            return null;
+        }
+        // todo: handle unknown method names
+
+        return null;
+    }
+}

--- a/src/Checker/ReferenceAssignmentChecker.php
+++ b/src/Checker/ReferenceAssignmentChecker.php
@@ -4,15 +4,10 @@
 namespace umulmrum\PhpReferenceChecker\Checker;
 
 
-use PhpParser\Node\Expr\AssignRef;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
 use Psr\Log\LoggerInterface;
-use SebastianBergmann\CodeCoverage\Report\Xml\Node;
 use Symfony\Component\Finder\Finder;
-use Traversable;
 use umulmrum\PhpReferenceChecker\DataModel\MethodRepository;
 use umulmrum\PhpReferenceChecker\DataModel\NonReferenceAssignmentWarning;
 

--- a/tests/Checker/ReferenceAssignmentCheckerTest.php
+++ b/tests/Checker/ReferenceAssignmentCheckerTest.php
@@ -106,6 +106,20 @@ class ReferenceAssignmentCheckerTest extends TestCase
         $this->thenIShouldReceiveNoWarning();
     }
 
+    public function testBlocks()
+    {
+        $this->givenAReferenceAssignmentChecker();
+        $this->whenICallCheckOn(
+            __DIR__.'/../fixtures/Blocks/Blocks.php',
+            include __DIR__ . '/../fixtures/Blocks/BlocksRepository.php'
+        );
+        $this->thenIShouldReceiveANonReferenceAssignmentWarningWith(
+            'Blocks.php',
+            18,
+            1.0
+        );
+    }
+
     private function givenAReferenceAssignmentChecker()
     {
         $this->checker = new ReferenceAssignmentChecker(new NullLogger());

--- a/tests/fixtures/Blocks/Blocks.php
+++ b/tests/fixtures/Blocks/Blocks.php
@@ -1,0 +1,23 @@
+<?php
+
+class BlocksOne {
+
+    public function foo() {
+        return 'bar';
+    }
+}
+
+class BlocksCaller {
+
+    public function bar($flag)
+    {
+        $c = 'foo';
+
+        if (true === $flag) {
+            $b = new BlocksOne();
+            $c =& $b->foo();
+        }
+
+        return $c;
+    }
+}

--- a/tests/fixtures/Blocks/BlocksRepository.php
+++ b/tests/fixtures/Blocks/BlocksRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+return new \umulmrum\PhpReferenceChecker\DataModel\MethodRepository(
+    [],
+    [
+        'foo' => 1,
+        'bar' => 1,
+    ]
+);


### PR DESCRIPTION
In order to recursively check sub nodes of block
this commit moves the code that checks for problematic
assignments into a visitor. This visitor is then used
by a NodeTraverser.

Fixes #9